### PR TITLE
Add support for latest package URL format

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -9,7 +9,7 @@ class asgard::install {
       cwd  => "${asgard::tomcat_dir}/webapps",
       path => [ '/bin', '/usr/bin' ];
     'wget asgard':
-      command  => "wget https://github.com/Netflix/asgard/releases/download/asgard-${asgard::version}/asgard.war",
+      command  => "wget https://github.com/Netflix/asgard/releases/download/asgard-${asgard::version}/asgard.war || wget https://github.com/Netflix/asgard/releases/download/${asgard::version}/asgard.war",
       cwd      => "${asgard::tomcat_dir}/webapps",
       path     => [ '/bin', '/usr/bin' ],
       require  => Exec['rm -rf *'];


### PR DESCRIPTION
The latest Asgard package uses a different URL scheme than the older ones: 

```
https://github.com/Netflix/asgard/releases/download/1.5.1/asgard.war
```

as opposed to:

```
https://github.com/Netflix/asgard/releases/download/asgard-1.5/asgard.war
```

This fix keeps compatibility with the old formatting.
